### PR TITLE
- api request returning caching value fix

### DIFF
--- a/src/Helpers/API/API.php
+++ b/src/Helpers/API/API.php
@@ -36,19 +36,28 @@ class API
         // Retrieve from cache
         $cache_key = Cache::buildKey($url, $params);
         if(($cache_value = Cache::get($cache_key)) !== null){
-            return (object) $cache_value;
+            return static::objectFromResponse($cache_value);
         }
 
         // Execute request to API
         $response = API::execute_request($url, $params);
         if($response->successful()){
-            $response_json = $response->json();
             // store in cache
             Cache::put($cache_key, $response, static::CACHE_TTL);
-            return json_decode(json_encode($response_json));
+            return static::objectFromResponse($response);
         } else {
             return (object) ['error' => 'Request to '.$url.' failed'];
         }
 
+    }
+
+    /**
+     * @param $response_value
+     * @return object - json_decoded response
+     */
+    private static function objectFromResponse($response_value): object
+    {
+        $value = $response_value->json();
+        return json_decode(json_encode($value));
     }
 }


### PR DESCRIPTION
a problem occurred when retrieving the value from cache the record property was retrieved as array and not object
the result of this was that no data   from dopa exist, when the information was retrieved from the cache, in the report page of the assessments and in scaling up